### PR TITLE
Use Agent.BuildDirectory instead of Agent.WorkFolder

### DIFF
--- a/tasks/synopsys-detect-task/ts/PathResolver.ts
+++ b/tasks/synopsys-detect-task/ts/PathResolver.ts
@@ -12,7 +12,7 @@ export class PathResolver {
     }
 
     static getWorkingDirectory(): string {
-        return task.getVariable('Agent.WorkFolder') || __dirname
+        return task.getVariable('Agent.BuildDirectory') || __dirname
     }
 
     static combinePathSegments(...pathSegments: string[]): string {


### PR DESCRIPTION
Agent.WorkFolder is not mounted as docker volume by Azure Pipelines, if
containers are used. This causes the SynopsisDetectTask to fail because
the detect folder cannot be created.

This commit changes the WorkingDirectory to Agent.BuildDirectory. The
detect folder can be created and the detect script can be downloaded
properly even from a container.