### PR TITLE
fix(#54): Disable axios proxy in favor of https-proxy-agent

### DIFF
--- a/tasks/synopsys-detect-task/ts/DetectScriptDownloader.ts
+++ b/tasks/synopsys-detect-task/ts/DetectScriptDownloader.ts
@@ -24,7 +24,8 @@ export class DetectScriptDownloader {
         const response = await axios({
             url: downloadLink,
             method: 'GET',
-            responseType: 'stream'
+            responseType: 'stream',
+            proxy: false // https://github.com/axios/axios/issues/2072#issuecomment-609650888
         })
 
         response.data.pipe(writer)


### PR DESCRIPTION
As mentioned in the issue #54, this disables the axios proxy in favor of `https-proxy-agent` (you're using) and applies the recommended configuration.