### PR TITLE
Dynamically populate legal Detect Version options

### DIFF
--- a/tasks/synopsys-detect-task/task.json
+++ b/tasks/synopsys-detect-task/task.json
@@ -88,6 +88,15 @@
       "visibleRule": "DetectRunMode = UseAirGap"
     }
   ],
+  "dataSourceBindings": [
+    {
+      "endpointId": "synopsys-detect-versions-endpoint",
+      "target": "DetectVersion",
+      "endpointUrl": "{{endpoint.url}}/artifactory/api/storage/bds-integrations-release/com/synopsys/integration/synopsys-detect/",
+      "resultSelector": "jsonpath:$.children[*]",
+      "resultTemplate": "{ \"Value\" : \"{{{uri}}}\", \"DisplayValue\" : \"{{{uri}}}\" }"
+    }
+  ],
   "execution": {
     "Node10": {
       "target": "detect-task.js"

--- a/tasks/synopsys-detect-task/task.json
+++ b/tasks/synopsys-detect-task/task.json
@@ -62,7 +62,7 @@
     },
     {
       "name": "DetectVersion",
-      "type": "string",
+      "type": "pickList",
       "label": "Detect Version",
       "defaultValue": "latest",
       "required": true,

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -144,6 +144,38 @@
           }
         ]
       }
+    },
+    {
+      "id": "synopsys-detect-versions-endpoint",
+      "description": "Service Endpoint for retrieving list of possible detect versions",
+      "type": "ms.vss-endpoint.service-endpoint-type",
+      "targets": [
+        "ms.vss-endpoint.endpoint-types"
+      ],
+      "properties": {
+        "name": "synopsysdetectartifactory",
+        "displayName": "SIG Repo Artifactory",
+        "url": {
+          "displayName": "Server URL",
+          "value": "https://sig-repo.synopsys.com",
+          "helpText": "This Service Endpoint URL is always fixed"
+        },
+        "authenticationSchemes": [
+          {
+            "id": "endpoint-auth-scheme-none",
+            "description": "Creates an endpoint authentication scheme with no authentication.",
+            "type": "ms.vss-endpoint.endpoint-auth-scheme-none",
+            "targets": [
+              "ms.vss-endpoint.endpoint-auth-schemes"
+            ],
+            "properties": {
+              "name": "None",
+              "displayName": "No Authentication"
+            }
+          }
+        ]
+      }
+
     }
   ]
 }


### PR DESCRIPTION
Hi maintainers!  I am not sure exactly how to test this capability at this point, but if you can point me in the right direction I would be happy to test it myself, or you can assist me in testing before accepting the PR.

The basic idea is to fetch the potential legal detect versions from https://sig-repo.synopsys.com/artifactory/api/storage/bds-integrations-release/com/synopsys/integration/synopsys-detect/ and use those versions to populate the Detect Version pick list for the ADO task.  We encountered a case of user error where the customer entered an invalid value here, so this would prevent such occurrences in the future.