### PR TITLE
Conditional logic for using agent's proxy configuration

### DIFF
--- a/tasks/synopsys-detect-task/detect-task.ts
+++ b/tasks/synopsys-detect-task/detect-task.ts
@@ -13,7 +13,6 @@ import {DetectJarConfigurationRunner} from './ts/runner/DetectJarConfigurationRu
 import {TaskResult} from 'azure-pipelines-task-lib';
 import {IDefaultScriptConfiguration} from './ts/model/IDefaultScriptConfiguration';
 import {IJarConfiguration} from './ts/model/IJarConfiguration';
-import tl = require('azure-pipelines-task-lib/task');
 
 async function run() {
     logger.info('Starting Detect Task')
@@ -65,7 +64,7 @@ function getBlackduckConfiguration(): IBlackduckConfiguration {
     const blackduckProxyService: string | undefined = task.getInput(DetectADOConstants.BLACKDUCK_PROXY_ID, false)
 
     // Agent's proxy configuration
-    const agentProxy = tl.getHttpProxyConfiguration()!
+    const agentProxy = task.getHttpProxyConfiguration()!
 
     if (blackduckProxyService) {
         const proxyUrl: string = task.getEndpointUrl(blackduckProxyService, true)!
@@ -81,8 +80,8 @@ function getBlackduckConfiguration(): IBlackduckConfiguration {
     // Use Agent's proxy configuration if BD Proxy Service Connection not used 
     } else if (agentProxy && blackduckProxyService === undefined) {          
         const proxyUrl: string = agentProxy.proxyUrl
-        const proxyUsername: string | undefined = agentProxy?.proxyUsername
-        const proxyPassword: string | undefined = agentProxy?.proxyPassword
+        const proxyUsername: string | undefined = agentProxy.proxyUsername
+        const proxyPassword: string | undefined = agentProxy.proxyPassword
 
         blackduckProxyInfo = {
             proxyUrl,


### PR DESCRIPTION
This enhancement is adding conditional logic for using the Agent's proxy configuration if the separate BD Proxy Service Endpoint is not used. Inheriting the Agent's proxy configuration is the recommended approach from Microsoft, and mitigates the need for users to worry about proxy configurations in each pipeline. The conditional logic is set to use the BD Proxy endpoint proxy details by default if configured in the pipeline, otherwise will use the Agent's proxy configuration if the agent does have a proxy configured. That way there should be no impact to existing customers. 

The Microsoft documentation for this approach can be found - 
https://github.com/Microsoft/azure-pipelines-task-lib/blob/master/node/docs/proxy.md

as well as here - https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/proxy?view=azure-devops&tabs=windows#how-the-agent-handles-the-proxy-within-a-build-or-release-job

"_Task authors need to use [azure-pipelines-task-lib](https://github.com/Microsoft/azure-pipelines-task-lib) methods to retrieve proxy configuration and [handle the proxy](https://github.com/Microsoft/azure-pipelines-task-lib/blob/master/node/docs/proxy.md) within their task_"

I tested this change in our ADO instance for various scenarios like running on cloud agents, on prem agents, different OS, with/without the BD Proxy endpoint selected, and everything was working well. Please let me know if you have any questions or there is anything I can help test with, etc. 