### PR TITLE
Add Fallback logic for Detect 9 scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "detect-ado",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "9.0.0",
+      "version": "9.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/node": "^14.14.5",
@@ -98,9 +98,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "14.18.61",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.61.tgz",
-      "integrity": "sha512-1mFT4DqS4/s9tlZbdkwEB/EnSykA9MDeDLIk3FHApGvIMGY//qgstB2gu9GKGESWyW/qiRUO+jhlLJ9bBJ8j+Q=="
+      "version": "14.18.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.0",
@@ -1663,9 +1663,9 @@
       }
     },
     "node_modules/jsonfile/node_modules/universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
       "engines": {
         "node": ">= 10.0.0"
@@ -1938,38 +1938,17 @@
         "node": ">=10"
       }
     },
-    "node_modules/normalize-package-data/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/normalize-package-data/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/normalize-package-data/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
     },
     "node_modules/normalize-path": {
       "version": "2.1.1",
@@ -3425,9 +3404,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.18.61",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.61.tgz",
-      "integrity": "sha512-1mFT4DqS4/s9tlZbdkwEB/EnSykA9MDeDLIk3FHApGvIMGY//qgstB2gu9GKGESWyW/qiRUO+jhlLJ9bBJ8j+Q=="
+      "version": "14.18.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -4724,9 +4703,9 @@
       },
       "dependencies": {
         "universalify": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+          "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
           "dev": true
         }
       }
@@ -4955,28 +4934,10 @@
         "validate-npm-package-license": "^3.0.1"
       },
       "dependencies": {
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
         "semver": {
-          "version": "7.5.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+          "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "detect-ado",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "description": "Execute Synopsys Detect against your build",
   "scripts": {
     "package": "tfx extension create --manifest-globs vss-extension.json",

--- a/tasks/synopsys-detect-task/package-lock.json
+++ b/tasks/synopsys-detect-task/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "detect-ado",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "detect-ado",
-      "version": "9.0.0",
+      "version": "9.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/jquery": "^2.0.34",
@@ -80,9 +80,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "14.18.61",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.61.tgz",
-      "integrity": "sha512-1mFT4DqS4/s9tlZbdkwEB/EnSykA9MDeDLIk3FHApGvIMGY//qgstB2gu9GKGESWyW/qiRUO+jhlLJ9bBJ8j+Q=="
+      "version": "14.18.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ=="
     },
     "node_modules/@types/q": {
       "version": "0.0.32",
@@ -903,9 +903,9 @@
       }
     },
     "node_modules/jsonfile/node_modules/universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -1929,9 +1929,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.18.61",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.61.tgz",
-      "integrity": "sha512-1mFT4DqS4/s9tlZbdkwEB/EnSykA9MDeDLIk3FHApGvIMGY//qgstB2gu9GKGESWyW/qiRUO+jhlLJ9bBJ8j+Q=="
+      "version": "14.18.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ=="
     },
     "@types/q": {
       "version": "0.0.32",
@@ -2599,9 +2599,9 @@
       },
       "dependencies": {
         "universalify": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+          "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="
         }
       }
     },

--- a/tasks/synopsys-detect-task/package.json
+++ b/tasks/synopsys-detect-task/package.json
@@ -1,6 +1,6 @@
 {
   "name": "detect-ado",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "description": "Execute Synopsys Detect against your build",
   "scripts": {
     "build": "tsc -p .",

--- a/tasks/synopsys-detect-task/task.json
+++ b/tasks/synopsys-detect-task/task.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 9,
     "Minor": 0,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "1.95.0",
   "instanceNameFormat": "Run Synopsys Detect for your build $(message)",

--- a/tasks/synopsys-detect-task/tests/DetectScriptDownloaderTest.ts
+++ b/tasks/synopsys-detect-task/tests/DetectScriptDownloaderTest.ts
@@ -15,7 +15,7 @@ describe('Detect script downloader tests', function () {
     })
 
     it('test script download', (done) => {
-        DetectScriptDownloader.downloadScript(undefined, DetectScriptConfigurationRunner.DETECT_SH_SCRIPT_NAME, folder).then(response => {
+        DetectScriptDownloader.downloadScript(undefined, DetectScriptConfigurationRunner.DETECT_SH_SCRIPT_NAME, folder, true).then(response => {
             assert.ok(fileSystem.existsSync(`${folder}/${DetectScriptConfigurationRunner.DETECT_SH_SCRIPT_NAME}`), 'Downloaded file did not exist')
         }).finally(done)
     });
@@ -27,7 +27,7 @@ describe('Detect script downloader tests', function () {
             proxyPassword: undefined
         }
 
-        DetectScriptDownloader.downloadScript(proxyInfo, DetectScriptConfigurationRunner.DETECT_SH_SCRIPT_NAME, folder)
+        DetectScriptDownloader.downloadScript(proxyInfo, DetectScriptConfigurationRunner.DETECT_SH_SCRIPT_NAME, folder, true)
             .then(() => {
                 assert.fail('Should have thrown exception')
             })

--- a/tasks/synopsys-detect-task/ts/DetectScriptDownloader.ts
+++ b/tasks/synopsys-detect-task/ts/DetectScriptDownloader.ts
@@ -9,42 +9,28 @@ import {PathResolver} from './PathResolver';
 export class DetectScriptDownloader {
     static readonly DETECT_DOWNLOAD_URL = 'https://detect.blackduck.com'
     static readonly DETECT_DOWNLOAD_FALLBACK_URL = 'https://detect.synopsys.com'
-    private static downloadLink: string;
 
     private constructor() {}
 
-    static async downloadScript(proxyInfo: IProxyInfo | undefined, scriptName: string, scriptDirectory: string): Promise<boolean> {
+    static async downloadScript(proxyInfo: IProxyInfo | undefined, scriptName: string, scriptDirectory: string, isBlackDuckAccessible: boolean): Promise<boolean> {
         logger.info('Downloading detect script.')
         if (!fileSystem.existsSync(scriptDirectory)) {
             fileSystem.mkdirSync(scriptDirectory, {recursive: true})
         }
         logger.info("Hello all")
 
+        let downloadLink:string
+        if(isBlackDuckAccessible) {
+            downloadLink = this.getFullDownloadUrl(scriptName)
+        } else {
+            downloadLink = this.getFullFallbackDownloadUrl(scriptName)
+        }
         const filePath: string = PathResolver.combinePathSegments(scriptDirectory, scriptName)
         const writer: WriteStream = fileSystem.createWriteStream(filePath)
         const axios: AxiosInstance = this.createAxiosAgent(proxyInfo)
 
-        logger.info(filePath, writer)
-
-        try {
-            logger.info("In try block")
-            const bdResponse = await axios.get(DetectScriptDownloader.DETECT_DOWNLOAD_URL)
-
-            if(bdResponse.status >= 200 && bdResponse.status <= 399) {
-                logger.info("In If block")
-                this.downloadLink = this.getFullDownloadUrl(scriptName);
-            } else {
-                logger.info("In else block")
-                logger.warn("https://detect.blackduck.com responded with an unexpected status code " + bdResponse.status + ". Please allow access through your firewall as https://sig-repo.synopsys.com will be shutdown at the end of February 2025.")
-                this.downloadLink = this.getFullFallbackDownloadUrl(scriptName)
-            }
-        } catch (error) {
-            logger.warn("https://detect.blackduck.com is inaccessible from this machine. Please allow access through your firewall as https://sig-repo.synopsys.com will be shutdown at the end of February 2025.")
-            this.downloadLink = this.getFullFallbackDownloadUrl(scriptName)
-        }
-
         const response = await axios({
-            url: this.downloadLink,
+            url: downloadLink,
             method: 'GET',
             responseType: 'stream'
         })
@@ -83,5 +69,9 @@ export class DetectScriptDownloader {
 
     private static getFullFallbackDownloadUrl(scriptName: string): string {
         return `${DetectScriptDownloader.DETECT_DOWNLOAD_FALLBACK_URL}/${scriptName}`
+    }
+
+    static async isBlackDuckUrlAccessible(): Promise<boolean> {
+        return false
     }
 }

--- a/tasks/synopsys-detect-task/ts/DetectScriptDownloader.ts
+++ b/tasks/synopsys-detect-task/ts/DetectScriptDownloader.ts
@@ -67,4 +67,8 @@ export class DetectScriptDownloader {
     private static getFullDownloadUrl(scriptName: string): string {
         return `${DetectScriptDownloader.DETECT_DOWNLOAD_URL}/${scriptName}`
     }
+
+    private static getFullFallbackDownloadUrl(scriptName: string): string {
+        return `${DetectScriptDownloader.DETECT_DOWNLOAD_FALLBACK_URL}/${scriptName}`
+    }
 }

--- a/tasks/synopsys-detect-task/ts/DetectScriptDownloader.ts
+++ b/tasks/synopsys-detect-task/ts/DetectScriptDownloader.ts
@@ -17,12 +17,7 @@ export class DetectScriptDownloader {
             fileSystem.mkdirSync(scriptDirectory, {recursive: true})
         }
 
-        let downloadLink:string
-        if(isBlackDuckAccessible) {
-            downloadLink = this.getFullDownloadUrl(scriptName)
-        } else {
-            downloadLink = this.getFullFallbackDownloadUrl(scriptName)
-        }
+        const downloadLink: string = this.getFullDownloadUrl(isBlackDuckAccessible, scriptName)
         const filePath: string = PathResolver.combinePathSegments(scriptDirectory, scriptName)
         const writer: WriteStream = fileSystem.createWriteStream(filePath)
         const axios: AxiosInstance = this.createAxiosAgent(proxyInfo)
@@ -62,11 +57,11 @@ export class DetectScriptDownloader {
         return Axios.create()
     }
 
-    private static getFullDownloadUrl(scriptName: string): string {
-        return `${DetectScriptDownloader.DETECT_DOWNLOAD_URL}/${scriptName}`
-    }
-
-    private static getFullFallbackDownloadUrl(scriptName: string): string {
-        return `${DetectScriptDownloader.DETECT_DOWNLOAD_FALLBACK_URL}/${scriptName}`
+    private static getFullDownloadUrl(isBlackDuckAccessible: boolean, scriptName: string): string {
+        if(isBlackDuckAccessible) {
+            return `${DetectScriptDownloader.DETECT_DOWNLOAD_URL}/${scriptName}`
+        } else {
+            return `${DetectScriptDownloader.DETECT_DOWNLOAD_FALLBACK_URL}/${scriptName}`
+        }
     }
 }

--- a/tasks/synopsys-detect-task/ts/DetectScriptDownloader.ts
+++ b/tasks/synopsys-detect-task/ts/DetectScriptDownloader.ts
@@ -13,12 +13,9 @@ export class DetectScriptDownloader {
     private constructor() {}
 
     static async downloadScript(proxyInfo: IProxyInfo | undefined, scriptName: string, scriptDirectory: string, isBlackDuckAccessible: boolean): Promise<boolean> {
-        logger.info(isBlackDuckAccessible + "isBlackduckAccessible")
-        logger.info('Downloading detect script.')
         if (!fileSystem.existsSync(scriptDirectory)) {
             fileSystem.mkdirSync(scriptDirectory, {recursive: true})
         }
-        logger.info("Hello all")
 
         let downloadLink:string
         if(isBlackDuckAccessible) {
@@ -30,6 +27,7 @@ export class DetectScriptDownloader {
         const writer: WriteStream = fileSystem.createWriteStream(filePath)
         const axios: AxiosInstance = this.createAxiosAgent(proxyInfo)
 
+        logger.info("Downloading Detect Script from: " + downloadLink)
         const response = await axios({
             url: downloadLink,
             method: 'GET',

--- a/tasks/synopsys-detect-task/ts/DetectScriptDownloader.ts
+++ b/tasks/synopsys-detect-task/ts/DetectScriptDownloader.ts
@@ -13,6 +13,7 @@ export class DetectScriptDownloader {
     private constructor() {}
 
     static async downloadScript(proxyInfo: IProxyInfo | undefined, scriptName: string, scriptDirectory: string, isBlackDuckAccessible: boolean): Promise<boolean> {
+        logger.info(isBlackDuckAccessible + "isBlackduckAccessible")
         logger.info('Downloading detect script.')
         if (!fileSystem.existsSync(scriptDirectory)) {
             fileSystem.mkdirSync(scriptDirectory, {recursive: true})
@@ -65,13 +66,5 @@ export class DetectScriptDownloader {
 
     private static getFullDownloadUrl(scriptName: string): string {
         return `${DetectScriptDownloader.DETECT_DOWNLOAD_URL}/${scriptName}`
-    }
-
-    private static getFullFallbackDownloadUrl(scriptName: string): string {
-        return `${DetectScriptDownloader.DETECT_DOWNLOAD_FALLBACK_URL}/${scriptName}`
-    }
-
-    static async isBlackDuckUrlAccessible(): Promise<boolean> {
-        return false
     }
 }

--- a/tasks/synopsys-detect-task/ts/runner/DetectScriptConfigurationRunner.ts
+++ b/tasks/synopsys-detect-task/ts/runner/DetectScriptConfigurationRunner.ts
@@ -62,14 +62,11 @@ export class DetectScriptConfigurationRunner extends DetectRunner {
         const axios: AxiosInstance = Axios.create()
 
         try {
-            logger.info("In try block")
             const bdResponse = await axios.get(DetectScriptDownloader.DETECT_DOWNLOAD_URL)
 
             if(bdResponse.status >= 200 && bdResponse.status <= 399) {
-                logger.info("In If block")
                 isBlackDuckAccessible = true;
             } else {
-                logger.info("In else block")
                 logger.warn("https://detect.blackduck.com responded with an unexpected status code " + bdResponse.status + ". Please allow access through your firewall as https://detect.synopsys.com will be shutdown at the end of February 2025.")
                 isBlackDuckAccessible = false
             }

--- a/tasks/synopsys-detect-task/ts/runner/DetectScriptConfigurationRunner.ts
+++ b/tasks/synopsys-detect-task/ts/runner/DetectScriptConfigurationRunner.ts
@@ -70,11 +70,11 @@ export class DetectScriptConfigurationRunner extends DetectRunner {
                 isBlackDuckAccessible = true;
             } else {
                 logger.info("In else block")
-                logger.warn("https://detect.blackduck.com responded with an unexpected status code " + bdResponse.status + ". Please allow access through your firewall as https://sig-repo.synopsys.com will be shutdown at the end of February 2025.")
+                logger.warn("https://detect.blackduck.com responded with an unexpected status code " + bdResponse.status + ". Please allow access through your firewall as https://detect.synopsys.com will be shutdown at the end of February 2025.")
                 isBlackDuckAccessible = false
             }
         } catch (error) {
-            logger.warn("https://detect.blackduck.com is inaccessible from this machine. Please allow access through your firewall as https://sig-repo.synopsys.com will be shutdown at the end of February 2025.")
+            logger.warn("https://detect.blackduck.com is inaccessible from this machine. Please allow access through your firewall as https://detect.synopsys.com will be shutdown at the end of February 2025.")
             isBlackDuckAccessible = false
         }
 

--- a/tasks/synopsys-detect-task/ts/runner/DetectScriptConfigurationRunner.ts
+++ b/tasks/synopsys-detect-task/ts/runner/DetectScriptConfigurationRunner.ts
@@ -67,11 +67,11 @@ export class DetectScriptConfigurationRunner extends DetectRunner {
             if(bdResponse.status >= 200 && bdResponse.status <= 399) {
                 isBlackDuckAccessible = true;
             } else {
-                logger.warn("https://detect.blackduck.com responded with an unexpected status code " + bdResponse.status + ". Please allow access through your firewall as https://detect.synopsys.com will be shutdown at the end of February 2025.")
+                logger.warn("https://detect.blackduck.com responded with an unexpected status code " + bdResponse.status + ".")
                 isBlackDuckAccessible = false
             }
         } catch (error) {
-            logger.warn("https://detect.blackduck.com is inaccessible from this machine. Please allow access through your firewall as https://detect.synopsys.com will be shutdown at the end of February 2025.")
+            logger.warn("https://detect.blackduck.com is inaccessible from this machine. Please allow access through your firewall.")
             isBlackDuckAccessible = false
         }
 

--- a/tasks/synopsys-detect-task/ts/runner/DetectScriptConfigurationRunner.ts
+++ b/tasks/synopsys-detect-task/ts/runner/DetectScriptConfigurationRunner.ts
@@ -9,6 +9,7 @@ import {DetectSetup} from '../DetectSetup';
 import {IBlackduckConfiguration} from '../model/IBlackduckConfiguration';
 import {IDetectConfiguration} from '../model/IDetectConfiguration';
 import {IDefaultScriptConfiguration} from '../model/IDefaultScriptConfiguration';
+import Axios, {AxiosInstance} from "axios";
 
 const osPlat: string = os.platform()
 
@@ -57,9 +58,28 @@ export class DetectScriptConfigurationRunner extends DetectRunner {
     async retrieveOrCreateArtifactFolder(fileName: string): Promise<string> {
         const workingDirectory = PathResolver.getWorkingDirectory() || ''
         const scriptFolder: string = PathResolver.combinePathSegments(workingDirectory, DetectADOConstants.SCRIPT_DETECT_FOLDER)
+        let isBlackDuckAccessible: boolean = true
+        const axios: AxiosInstance = Axios.create()
 
         try {
-            await DetectScriptDownloader.downloadScript(this.blackduckConfiguration.proxyInfo, fileName, scriptFolder)
+            logger.info("In try block")
+            const bdResponse = await axios.get(DetectScriptDownloader.DETECT_DOWNLOAD_URL)
+
+            if(bdResponse.status >= 200 && bdResponse.status <= 399) {
+                logger.info("In If block")
+                isBlackDuckAccessible = true;
+            } else {
+                logger.info("In else block")
+                logger.warn("https://detect.blackduck.com responded with an unexpected status code " + bdResponse.status + ". Please allow access through your firewall as https://sig-repo.synopsys.com will be shutdown at the end of February 2025.")
+                isBlackDuckAccessible = false
+            }
+        } catch (error) {
+            logger.warn("https://detect.blackduck.com is inaccessible from this machine. Please allow access through your firewall as https://sig-repo.synopsys.com will be shutdown at the end of February 2025.")
+            isBlackDuckAccessible = false
+        }
+
+        try {
+            await DetectScriptDownloader.downloadScript(this.blackduckConfiguration.proxyInfo, fileName, scriptFolder, isBlackDuckAccessible)
         } catch (error) {
             logger.error(`Unable to connect with ${DetectScriptDownloader.DETECT_DOWNLOAD_URL}`)
             logger.error('This may be a problem with your proxy setup or network.')

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1,
   "id": "synopsys-detect-qa",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "name": "Synopsys Detect QA",
   "publisher": "synopsys-detect",
   "public": false,


### PR DESCRIPTION
This PR will handle the download of detect scripts from detect.blackduck.com. If the user has not allowed access for this site through firewall then we will fallback to detect.synopsys.com to download the scripts. Users should allow detect.blackduck.com through firewalls. 