### PR TITLE
Add fallback logic for previous detect jars

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "detect-ado",
       "version": "10.0.0",
       "license": "Apache-2.0",
       "dependencies": {

--- a/tasks/blackduck-detect-task/ts/runner/DetectJarConfigurationRunner.ts
+++ b/tasks/blackduck-detect-task/ts/runner/DetectJarConfigurationRunner.ts
@@ -9,6 +9,7 @@ import {logger} from '../DetectLogger';
 
 export class DetectJarConfigurationRunner extends DetectRunner {
     private static readonly JAR_PREFIX = 'detect-'
+    private static readonly FALLBACK_JAR_PREFIX = 'synopsys-detect-'
     private static readonly JAR_EXTENSION = '.jar'
 
     private readonly jarDirectoryPath: string
@@ -27,7 +28,7 @@ export class DetectJarConfigurationRunner extends DetectRunner {
         const firstJarFile: string = fileSystem.readdirSync(this.jarDirectoryPath)
             .find(file => DetectJarConfigurationRunner.JAR_EXTENSION === path.parse(file).ext) || ''
 
-        if (!firstJarFile || !firstJarFile.startsWith(DetectJarConfigurationRunner.JAR_PREFIX)) {
+        if (!firstJarFile || (!firstJarFile.startsWith(DetectJarConfigurationRunner.JAR_PREFIX) && !firstJarFile.startsWith(DetectJarConfigurationRunner.FALLBACK_JAR_PREFIX))) {
             logger.warn('Should have only the detect jar in this directory.')
             throw new Error(`Was unable to find valid jar in ${this.jarDirectoryPath}.`)
         } else {


### PR DESCRIPTION
This PR handles the Jar execution strategy for ADO plugin to support running jars for earlier versions of detect when passed on in Air Gap Strategy. Users have the freedom to provide and run earlier versions of detect using the latest plugin but since we changed the name of detect jar, we will have to add fallback logic same as we did for scripts.