### PR TITLE
Allow 9.0.1 plugin to run new Detect JARS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "detect-ado",
       "version": "9.0.1",
       "license": "Apache-2.0",
       "dependencies": {

--- a/tasks/synopsys-detect-task/ts/runner/DetectJarConfigurationRunner.ts
+++ b/tasks/synopsys-detect-task/ts/runner/DetectJarConfigurationRunner.ts
@@ -9,6 +9,7 @@ import {logger} from '../DetectLogger';
 
 export class DetectJarConfigurationRunner extends DetectRunner {
     private static readonly JAR_PREFIX = 'synopsys-detect-'
+    private static readonly NEW_JAR_PREFIX = 'detect-'
     private static readonly JAR_EXTENSION = '.jar'
 
     private readonly jarDirectoryPath: string
@@ -27,7 +28,8 @@ export class DetectJarConfigurationRunner extends DetectRunner {
         const firstJarFile: string = fileSystem.readdirSync(this.jarDirectoryPath)
             .find(file => DetectJarConfigurationRunner.JAR_EXTENSION === path.parse(file).ext) || ''
 
-        if (!firstJarFile || !firstJarFile.startsWith(DetectJarConfigurationRunner.JAR_PREFIX)) {
+
+            if (!firstJarFile || (!firstJarFile.startsWith(DetectJarConfigurationRunner.JAR_PREFIX) && !firstJarFile.startsWith(DetectJarConfigurationRunner.NEW_JAR_PREFIX))) {
             logger.warn('Should have only the detect jar in this directory.')
             throw new Error(`Was unable to find valid jar in ${this.jarDirectoryPath}.`)
         } else {


### PR DESCRIPTION
Adding the same changes as we did for 10.0.0 here: https://github.com/blackducksoftware/detect-ado/commit/15e22f8afdfbc6c17961795a83b2bdda79d9c5aa#diff-56e44342a8e60bdb926d9e80dd044abda22ef3bc717191cce0849444fc0857a5R11 