### PR TITLE
supply chain fix

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-registry=https://registry.npmjs.org/
+registry=https://artifactory.tools.duckutil.net:443/artifactory/api/npm/npm-virtual/


### PR DESCRIPTION
This moves us away from using the public npm repository and instead uses a repository that has been vetted and confirmed to have safe packages.