### PR TITLE
fix adm-zip vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -139,13 +139,13 @@
       "dev": true
     },
     "node_modules/adm-zip": {
-      "version": "0.5.18",
-      "resolved": "https://artifactory.tools.duckutil.net:443/artifactory/api/npm/npm-virtual/adm-zip/-/adm-zip-0.5.18.tgz",
-      "integrity": "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==",
+      "version": "0.6.0",
+      "resolved": "https://artifactory.tools.duckutil.net:443/artifactory/api/npm/npm-virtual/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -139,9 +139,9 @@
       "dev": true
     },
     "node_modules/adm-zip": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
-      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+      "version": "0.5.18",
+      "resolved": "https://artifactory.tools.duckutil.net:443/artifactory/api/npm/npm-virtual/adm-zip/-/adm-zip-0.5.18.tgz",
+      "integrity": "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "y18n": "^4.0.1"
   },
   "overrides": {
-    "adm-zip": "^0.5.18"
+    "adm-zip": "0.6.0"
   },
   "dependencies": {
     "ts-node": "^9.0.0"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
     "vss-web-extension-sdk": "^2.109.0",
     "y18n": "^4.0.1"
   },
+  "overrides": {
+    "adm-zip": "^0.5.18"
+  },
   "dependencies": {
     "ts-node": "^9.0.0"
   }

--- a/tasks/blackduck-detect-task/package-lock.json
+++ b/tasks/blackduck-detect-task/package-lock.json
@@ -286,7 +286,9 @@
       "license": "MIT"
     },
     "node_modules/adm-zip": {
-      "version": "0.5.16",
+      "version": "0.5.18",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.18.tgz",
+      "integrity": "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==",
       "license": "MIT",
       "engines": {
         "node": ">=12.0"

--- a/tasks/blackduck-detect-task/package-lock.json
+++ b/tasks/blackduck-detect-task/package-lock.json
@@ -286,12 +286,12 @@
       "license": "MIT"
     },
     "node_modules/adm-zip": {
-      "version": "0.5.18",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.18.tgz",
-      "integrity": "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {

--- a/tasks/blackduck-detect-task/package.json
+++ b/tasks/blackduck-detect-task/package.json
@@ -23,7 +23,7 @@
     "y18n": "^4.0.1"
   },
   "overrides": {
-    "adm-zip": "^0.5.18",
+    "adm-zip": "0.6.0",
     "brace-expansion": "^1.1.12"
   },
   "dependencies": {

--- a/tasks/blackduck-detect-task/package.json
+++ b/tasks/blackduck-detect-task/package.json
@@ -23,6 +23,7 @@
     "y18n": "^4.0.1"
   },
   "overrides": {
+    "adm-zip": "^0.5.18",
     "brace-expansion": "^1.1.12"
   },
   "dependencies": {


### PR DESCRIPTION
This moves to the 0.6.0 version of adm-zip which is not currently vulnerable.

Note: the lock files do not need to be reviewed and are just instructions for builds that npm itself generated from the other json files.